### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-gc [![Build Status](https://secure.travis-ci.org/sonots/fluent-plugin-gc.png?branch=master)](http://travis-ci.org/sonots/fluent-plugin-gc)
+# fluent-plugin-gc, a plugin for [Fluentd](http://fluentd.org) [![Build Status](https://secure.travis-ci.org/sonots/fluent-plugin-gc.png?branch=master)](http://travis-ci.org/sonots/fluent-plugin-gc)
 
 Fluentd plugin to disable GC and start GC at arbitrary interval. This plugin is for testing only. 
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
